### PR TITLE
Pin notebook<7

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About jupyter_contrib_nbextensions
-==================================
+About jupyter_contrib_nbextensions-feedstock
+============================================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupyter_contrib_nbextensions-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/ipython-contrib/jupyter_contrib_nbextensions
 
 Package license: BSD-3-Clause
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupyter_contrib_nbextensions-feedstock/blob/main/LICENSE.txt)
 
 Summary: A collection of various different notebook extensions for Jupyter
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 06e33f005885eb92f89cbe82711e921278201298d08ab0d886d1ba09e8c3e9ca
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
@@ -29,7 +29,7 @@ requirements:
     - jupyter_nbextensions_configurator >=0.4.0
     - lxml
     - nbconvert >=4.2
-    - notebook >=4.0
+    - notebook >=4.0,<7
     - pyyaml
     - tornado
     - traitlets >=4.1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The transition from notebook 6.* to 7.0 came with a lot of breaking changes: see https://github.com/jupyter/notebook/compare/6.4.12...v7.0.0 for the diff. This package breaks with `notebook>=7`, because among other things, it expects the module `notebook.nbextensions` to exist.

Partial traceback from running `conda mambabuild` on the current feedstock:

```
## Package Plan ##

  environment location: /opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold


The following NEW packages will be INSTALLED:

    _libgcc_mutex:                     0.1-conda_forge            conda-forge
    _openmp_mutex:                     4.5-2_gnu                  conda-forge
    anyio:                             3.7.1-pyhd8ed1ab_0         conda-forge
    argon2-cffi:                       21.3.0-pyhd8ed1ab_0        conda-forge
    argon2-cffi-bindings:              21.2.0-py310h5764c6d_3     conda-forge
    asttokens:                         2.2.1-pyhd8ed1ab_0         conda-forge
    async-lru:                         2.0.3-pyhd8ed1ab_0         conda-forge
    attrs:                             23.1.0-pyh71513ae_1        conda-forge
    babel:                             2.12.1-pyhd8ed1ab_1        conda-forge
    backcall:                          0.2.0-pyh9f0ad1d_0         conda-forge
    backports:                         1.0-pyhd8ed1ab_3           conda-forge
    backports.functools_lru_cache:     1.6.5-pyhd8ed1ab_0         conda-forge
    beautifulsoup4:                    4.12.2-pyha770c72_0        conda-forge
    bleach:                            6.0.0-pyhd8ed1ab_0         conda-forge
    brotli-python:                     1.0.9-py310hd8f1fbe_9      conda-forge
    bzip2:                             1.0.8-h7f98852_4           conda-forge
    ca-certificates:                   2023.5.7-hbcca054_0        conda-forge
    certifi:                           2023.5.7-pyhd8ed1ab_0      conda-forge
    cffi:                              1.15.1-py310h255011f_3     conda-forge
    charset-normalizer:                3.2.0-pyhd8ed1ab_0         conda-forge
    comm:                              0.1.3-pyhd8ed1ab_0         conda-forge
    debugpy:                           1.6.7-py310heca2aa9_0      conda-forge
    decorator:                         5.1.1-pyhd8ed1ab_0         conda-forge
    defusedxml:                        0.7.1-pyhd8ed1ab_0         conda-forge
    entrypoints:                       0.4-pyhd8ed1ab_0           conda-forge
    exceptiongroup:                    1.1.2-pyhd8ed1ab_0         conda-forge
    executing:                         1.2.0-pyhd8ed1ab_0         conda-forge
    flit-core:                         3.9.0-pyhd8ed1ab_0         conda-forge
    gmp:                               6.2.1-h58526e2_0           conda-forge
    icu:                               72.1-hcb278e6_0            conda-forge
    idna:                              3.4-pyhd8ed1ab_0           conda-forge
    importlib-metadata:                6.8.0-pyha770c72_0         conda-forge
    importlib_metadata:                6.8.0-hd8ed1ab_0           conda-forge
    importlib_resources:               6.0.0-pyhd8ed1ab_1         conda-forge
    ipykernel:                         6.24.0-pyh71e2992_0        conda-forge
    ipython:                           8.14.0-pyh41d4057_0        conda-forge
    ipython_genutils:                  0.2.0-py_1                 conda-forge
    jedi:                              0.18.2-pyhd8ed1ab_0        conda-forge
    jinja2:                            3.1.2-pyhd8ed1ab_1         conda-forge
    json5:                             0.9.14-pyhd8ed1ab_0        conda-forge
    jsonschema:                        4.18.4-pyhd8ed1ab_0        conda-forge
    jsonschema-specifications:         2023.7.1-pyhd8ed1ab_0      conda-forge
    jupyter-lsp:                       2.2.0-pyhd8ed1ab_0         conda-forge
    jupyter_client:                    8.3.0-pyhd8ed1ab_0         conda-forge
    jupyter_contrib_core:              0.4.0-pyhd8ed1ab_0         conda-forge
    jupyter_contrib_nbextensions:      0.7.0-py_0                 local      
    jupyter_core:                      5.3.1-py310hff52083_0      conda-forge
    jupyter_events:                    0.6.3-pyhd8ed1ab_0         conda-forge
    jupyter_highlight_selected_word:   0.2.0-py310hff52083_1005   conda-forge
    jupyter_latex_envs:                1.4.6-pyhd8ed1ab_1002      conda-forge
    jupyter_nbextensions_configurator: 0.6.1-pyhd8ed1ab_0         conda-forge
    jupyter_server:                    2.7.0-pyhd8ed1ab_0         conda-forge
    jupyter_server_terminals:          0.4.4-pyhd8ed1ab_1         conda-forge
    jupyterlab:                        4.0.3-pyhd8ed1ab_0         conda-forge
    jupyterlab_pygments:               0.2.2-pyhd8ed1ab_0         conda-forge
    jupyterlab_server:                 2.23.0-pyhd8ed1ab_0        conda-forge
    ld_impl_linux-64:                  2.40-h41732ed_0            conda-forge
    libffi:                            3.4.2-h7f98852_5           conda-forge
    libgcc-ng:                         13.1.0-he5830b7_0          conda-forge
    libgomp:                           13.1.0-he5830b7_0          conda-forge
    libiconv:                          1.17-h166bdaf_0            conda-forge
    libnsl:                            2.0.0-h7f98852_0           conda-forge
    libsodium:                         1.0.18-h36c2ea0_1          conda-forge
    libsqlite:                         3.42.0-h2797004_0          conda-forge
    libstdcxx-ng:                      13.1.0-hfd8a6a1_0          conda-forge
    libuuid:                           2.38.1-h0b41bf4_0          conda-forge
    libxml2:                           2.11.4-h0d562d8_0          conda-forge
    libxslt:                           1.1.37-h0054252_1          conda-forge
    libzlib:                           1.2.13-hd590300_5          conda-forge
    lxml:                              4.9.3-py310h9b7343a_0      conda-forge
    markupsafe:                        2.1.3-py310h2372a71_0      conda-forge
    matplotlib-inline:                 0.1.6-pyhd8ed1ab_0         conda-forge
    mistune:                           3.0.0-pyhd8ed1ab_0         conda-forge
    nbclient:                          0.8.0-pyhd8ed1ab_0         conda-forge
    nbconvert:                         7.7.1-pyhd8ed1ab_1         conda-forge
    nbconvert-core:                    7.7.1-pyhd8ed1ab_1         conda-forge
    nbconvert-pandoc:                  7.7.1-pyhd8ed1ab_1         conda-forge
    nbformat:                          5.9.1-pyhd8ed1ab_0         conda-forge
    ncurses:                           6.4-hcb278e6_0             conda-forge
    nest-asyncio:                      1.5.6-pyhd8ed1ab_0         conda-forge
    notebook:                          7.0.0-pyhd8ed1ab_0         conda-forge
    notebook-shim:                     0.2.3-pyhd8ed1ab_0         conda-forge
    openssl:                           3.1.1-hd590300_1           conda-forge
    overrides:                         7.3.1-pyhd8ed1ab_0         conda-forge
    packaging:                         23.1-pyhd8ed1ab_0          conda-forge
    pandoc:                            3.1.3-h32600fe_0           conda-forge
    pandocfilters:                     1.5.0-pyhd8ed1ab_0         conda-forge
    parso:                             0.8.3-pyhd8ed1ab_0         conda-forge
    pexpect:                           4.8.0-pyh1a96a4e_2         conda-forge
    pickleshare:                       0.7.5-py_1003              conda-forge
    pip:                               23.2-pyhd8ed1ab_0          conda-forge
    pkgutil-resolve-name:              1.3.10-pyhd8ed1ab_0        conda-forge
    platformdirs:                      3.9.1-pyhd8ed1ab_0         conda-forge
    prometheus_client:                 0.17.1-pyhd8ed1ab_0        conda-forge
    prompt-toolkit:                    3.0.39-pyha770c72_0        conda-forge
    prompt_toolkit:                    3.0.39-hd8ed1ab_0          conda-forge
    psutil:                            5.9.5-py310h1fa729e_0      conda-forge
    ptyprocess:                        0.7.0-pyhd3deb0d_0         conda-forge
    pure_eval:                         0.2.2-pyhd8ed1ab_0         conda-forge
    pycparser:                         2.21-pyhd8ed1ab_0          conda-forge
    pygments:                          2.15.1-pyhd8ed1ab_0        conda-forge
    pysocks:                           1.7.1-pyha2e5f31_6         conda-forge
    python:                            3.10.12-hd12c33a_0_cpython conda-forge
    python-dateutil:                   2.8.2-pyhd8ed1ab_0         conda-forge
    python-fastjsonschema:             2.17.1-pyhd8ed1ab_0        conda-forge
    python-json-logger:                2.0.7-pyhd8ed1ab_0         conda-forge
    python_abi:                        3.10-3_cp310               conda-forge
    pytz:                              2023.3-pyhd8ed1ab_0        conda-forge
    pyyaml:                            6.0-py310h5764c6d_5        conda-forge
    pyzmq:                             25.1.0-py310h5bbb5d0_0     conda-forge
    readline:                          8.2-h8228510_1             conda-forge
    referencing:                       0.30.0-pyhd8ed1ab_0        conda-forge
    requests:                          2.31.0-pyhd8ed1ab_0        conda-forge
    rfc3339-validator:                 0.1.4-pyhd8ed1ab_0         conda-forge
    rfc3986-validator:                 0.1.1-pyh9f0ad1d_0         conda-forge
    rpds-py:                           0.9.2-py310hcb5633a_0      conda-forge
    send2trash:                        1.8.2-pyh41d4057_0         conda-forge
    setuptools:                        68.0.0-pyhd8ed1ab_0        conda-forge
    six:                               1.16.0-pyh6c4a22f_0        conda-forge
    sniffio:                           1.3.0-pyhd8ed1ab_0         conda-forge
    soupsieve:                         2.3.2.post1-pyhd8ed1ab_0   conda-forge
    stack_data:                        0.6.2-pyhd8ed1ab_0         conda-forge
    terminado:                         0.17.1-pyh41d4057_0        conda-forge
    tinycss2:                          1.2.1-pyhd8ed1ab_0         conda-forge
    tk:                                8.6.12-h27826a3_0          conda-forge
    tomli:                             2.0.1-pyhd8ed1ab_0         conda-forge
    tornado:                           6.3.2-py310h2372a71_0      conda-forge
    traitlets:                         5.9.0-pyhd8ed1ab_0         conda-forge
    typing-extensions:                 4.7.1-hd8ed1ab_0           conda-forge
    typing_extensions:                 4.7.1-pyha770c72_0         conda-forge
    typing_utils:                      0.1.0-pyhd8ed1ab_0         conda-forge
    tzdata:                            2023c-h71feb2d_0           conda-forge
    urllib3:                           2.0.4-pyhd8ed1ab_0         conda-forge
    wcwidth:                           0.2.6-pyhd8ed1ab_0         conda-forge
    webencodings:                      0.5.1-py_1                 conda-forge
    websocket-client:                  1.6.1-pyhd8ed1ab_0         conda-forge
    wheel:                             0.40.0-pyhd8ed1ab_1        conda-forge
    xz:                                5.2.6-h166bdaf_0           conda-forge
    yaml:                              0.2.5-h7f98852_2           conda-forge
    zeromq:                            4.3.4-h9c3ff4c_1           conda-forge
    zipp:                              3.16.2-pyhd8ed1ab_0        conda-forge
    zlib:                              1.2.13-hd590300_5          conda-forge

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 6, in <module>
    from notebook.extensions import BaseExtensionApp
ModuleNotFoundError: No module named 'notebook.extensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 10, in <module>
    from notebook.nbextensions import BaseNBExtensionApp
ModuleNotFoundError: No module named 'notebook.nbextensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 12, in <module>
    from ._compat.nbextensions import BaseNBExtensionApp
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/_compat/nbextensions.py", line 35, in <module>
    from notebook.nbextensions import (
ModuleNotFoundError: No module named 'notebook.nbextensions'

Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 6, in <module>
    from notebook.extensions import BaseExtensionApp
ModuleNotFoundError: No module named 'notebook.extensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 10, in <module>
    from notebook.nbextensions import BaseNBExtensionApp
ModuleNotFoundError: No module named 'notebook.nbextensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 12, in <module>
    from ._compat.nbextensions import BaseNBExtensionApp
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/_compat/nbextensions.py", line 35, in <module>
    from notebook.nbextensions import (
ModuleNotFoundError: No module named 'notebook.nbextensions'

Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/bin/jupyter-nbextensions_configurator", line 7, in <module>
    from jupyter_nbextensions_configurator.application import main
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_nbextensions_configurator/__init__.py", line 17, in <module>
    from notebook import version_info as nb_version_info
ImportError: cannot import name 'version_info' from 'notebook' (/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/notebook/__init__.py)

Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 6, in <module>
    from notebook.extensions import BaseExtensionApp
ModuleNotFoundError: No module named 'notebook.extensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 10, in <module>
    from notebook.nbextensions import BaseNBExtensionApp
ModuleNotFoundError: No module named 'notebook.nbextensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/bin/jupyter-contrib-nbextension", line 7, in <module>
    from jupyter_contrib_nbextensions.application import main
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_nbextensions/application.py", line 7, in <module>
    from jupyter_contrib_core.notebook_compat.nbextensions import ArgumentConflict
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 12, in <module>
    from ._compat.nbextensions import BaseNBExtensionApp
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/_compat/nbextensions.py", line 35, in <module>
    from notebook.nbextensions import (
ModuleNotFoundError: No module named 'notebook.nbextensions'

done
ERROR conda.core.link:_execute(745): An error occurred while installing package 'conda-forge::jupyter_highlight_selected_word-0.2.0-py310hff52083_1005'.
Rolling back transaction: ...working... done
Traceback (most recent call last):
  File "/opt/conda/bin/conda-mambabuild", line 10, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.10/site-packages/boa/cli/mambabuild.py", line 256, in main
    call_conda_build(action, config)
  File "/opt/conda/lib/python3.10/site-packages/boa/cli/mambabuild.py", line 228, in call_conda_build
    result = api.build(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/api.py", line 253, in build
    return build_tree(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/build.py", line 3814, in build_tree
    test(pkg, config=metadata.config.copy(), stats=stats)
  File "/opt/conda/lib/python3.10/site-packages/conda_build/build.py", line 3557, in test
    environ.create_env(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/environ.py", line 1058, in create_env
    execute_actions(actions, index)
  File "/opt/conda/lib/python3.10/site-packages/conda/common/io.py", line 84, in decorated
    return f(*args, **kwds)
  File "/opt/conda/lib/python3.10/site-packages/conda/plan.py", line 318, in execute_actions
    execute_instructions(plan, index, verbose)
  File "/opt/conda/lib/python3.10/site-packages/conda/plan.py", line 529, in execute_instructions
    cmd(state, arg)
  File "/opt/conda/lib/python3.10/site-packages/conda/instructions.py", line 71, in UNLINKLINKTRANSACTION_CMD
    unlink_link_transaction.execute()
  File "/opt/conda/lib/python3.10/site-packages/conda/core/link.py", line 286, in execute
    self._execute(
  File "/opt/conda/lib/python3.10/site-packages/conda/core/link.py", line 761, in _execute
    raise CondaMultiError(
conda.CondaMultiError: post-link script failed for package conda-forge::jupyter_highlight_selected_word-0.2.0-py310hff52083_1005
location of failed script: /opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/bin/.jupyter_highlight_selected_word-post-link.sh
==> script messages <==
Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 6, in <module>
    from notebook.extensions import BaseExtensionApp
ModuleNotFoundError: No module named 'notebook.extensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 10, in <module>
    from notebook.nbextensions import BaseNBExtensionApp
ModuleNotFoundError: No module named 'notebook.nbextensions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 12, in <module>
    from ._compat.nbextensions import BaseNBExtensionApp
  File "/opt/conda/conda-bld/jupyter_contrib_nbextensions_1689876428188/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.10/site-packages/jupyter_contrib_core/notebook_compat/_compat/nbextensions.py", line 35, in <module>
    from notebook.nbextensions import (
ModuleNotFoundError: No module named 'notebook.nbextensions'

==> script output <==
stdout: 
stderr: 
return code: 1

()
```

@conda-forge-admin, please rerender